### PR TITLE
Add CronJobs and ElasticSearch to Helm Chart

### DIFF
--- a/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
@@ -10,6 +10,7 @@ data:
   CELERY_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/"
   DJANGO_DB_NAME: postgres
   DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
+  ELASTIC_SEARCH_HOST: "{{ template "ifrcgo-helm.fullname" . }}-elasticsearch" #FIXME: double check format
   DOCKER_HOST_IP: {{ .Values.env.DOCKER_HOST_IP | quote }}
   DJANGO_ADDITIONAL_ALLOWED_HOSTS: {{ .Values.env.DJANGO_ADDITIONAL_ALLOWED_HOSTS | quote }}
   GO_ENVIRONMENT: {{ .Values.env.GO_ENVIRONMENT | quote }}

--- a/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/config/configmap.yaml
@@ -10,7 +10,7 @@ data:
   CELERY_REDIS_URL: "redis://{{ template "ifrcgo-helm.fullname" . }}-redis:6379/"
   DJANGO_DB_NAME: postgres
   DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
-  ELASTIC_SEARCH_HOST: "{{ template "ifrcgo-helm.fullname" . }}-elasticsearch" #FIXME: double check format
+  ELASTIC_SEARCH_HOST: "elasticsearch://{{ template "ifrcgo-helm.fullname" . }}-elasticsearch:9200" #FIXME: double check format
   DOCKER_HOST_IP: {{ .Values.env.DOCKER_HOST_IP | quote }}
   DJANGO_ADDITIONAL_ALLOWED_HOSTS: {{ .Values.env.DJANGO_ADDITIONAL_ALLOWED_HOSTS | quote }}
   GO_ENVIRONMENT: {{ .Values.env.GO_ENVIRONMENT | quote }}

--- a/deploy/helm/ifrcgo-helm/templates/cronjobs/jobs.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/cronjobs/jobs.yaml
@@ -1,0 +1,27 @@
+{{- range $i, $job := .Values.cronjobs }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "ifrcgo-helm.fullname" $ }}-{{ $job.command | trunc 8 | nospace | lower | replace "_" "-" }}-{{ $i }}
+  labels:
+    component: api-jobs
+    environment: {{ $.Values.environment }}
+    release: {{ $.Release.Name }}
+spec:
+  schedule: {{ $job.schedule }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: {{ template "ifrcgo-helm.fullname" $ }}-{{ $job.command | trunc 8 | nospace | lower | replace "_" "-" }}-{{ $i }}
+              image: "{{ $.Values.api.image.name }}:{{ $.Values.api.image.tag }}"
+              command: ["sh", "python manage.py {{ $job.command }}"]
+              #FIXME: add resources
+              envFrom:
+                - secretRef:
+                    name: {{ template "ifrcgo-helm.fullname" $ }}-api-secret
+                - configMapRef:
+                    name: {{ template "ifrcgo-helm.fullname" $ }}-api-configmap
+              #FIXME: Add onFailure policy, retries, etc.
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/elasticsearch/pv.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/elasticsearch/pv.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.elasticsearch.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "ifrcgo-helm.fullname" . }}-elasticsearch-pv
+  labels:
+    component: elasticsearch
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  capacity:
+    storage: {{ .Values.elasticsearch.storageSize }}
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: managed-premium
+  azureDisk:
+    diskName: {{ .Values.elasticsearch.disk.name }}
+    diskURI: {{ .Values.elasticsearch.disk.uri }}
+
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/templates/elasticsearch/pvc.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/elasticsearch/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "ifrcgo-helm.fullname" . }}-elasticsearch-pvc
+  labels:
+    component: elasticsearch
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.elasticsearch.storageSize }}
+  storageClassName: managed-premium
+  volumeName:  {{ template "ifrcgo-helm.fullname" . }}-elasticsearch-pv

--- a/deploy/helm/ifrcgo-helm/templates/elasticsearch/service.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/elasticsearch/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.elasticsearch.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ifrcgo-helm.fullname" . }}-elasticsearch
+  labels:
+    component: elasticsearch
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ template "ifrcgo-helm.name" . }}
+    release: {{ .Release.Name }}
+    run: {{ .Release.Name }}-elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+  type: ClusterIP

--- a/deploy/helm/ifrcgo-helm/templates/elasticsearch/statefulset.yaml
+++ b/deploy/helm/ifrcgo-helm/templates/elasticsearch/statefulset.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.elasticsearch.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "ifrcgo-helm.fullname" . }}-elasticsearch
+  labels:
+    component: elasticsearch
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  serviceName: {{ template "ifrcgo-helm.fullname" . }}-elasticsearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "ifrcgo-helm.name" . }}
+      release: {{ .Release.Name }}
+      run: {{ .Release.Name }}-elasticsearch
+  template:
+    metadata:
+      labels:
+        app: {{ template "ifrcgo-helm.name" . }}
+        release: {{ .Release.Name }}
+        run: {{ .Release.Name }}-elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:{{ .Values.elasticsearch.elasticsearchVersion }}
+          env:
+            - name: "discovery.type"
+              value: "single-node"
+            - name: "cluster.name"
+              value: "{{ template "ifrcgo-helm.fullname" . }}-elasticsearch"
+          ports:
+            - containerPort: {{ .Values.httpPort }}
+              name: http
+            - containerPort: {{ .Values.transportPort }}
+              name: transport
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ template "ifrcgo-helm.fullname" . }}-elasticsearch-pvc
+
+{{- end }}

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -76,3 +76,11 @@ celery:
     limits:
       cpu: "2"
       memory: 4Gi
+
+cronjobs:
+  - command: 'ingest_appeal_docs'
+    schedule: '15 * * * *'
+  - command: 'ingest_mdb'
+    schedule: '30 * * * *'
+  - command: 'ingest_appeals'
+    schedule: '45 * * * *'

--- a/deploy/helm/ifrcgo-helm/values.yaml
+++ b/deploy/helm/ifrcgo-helm/values.yaml
@@ -84,3 +84,23 @@ cronjobs:
     schedule: '30 * * * *'
   - command: 'ingest_appeals'
     schedule: '45 * * * *'
+
+elasticsearch:
+  enabled: true
+  httpPort: 9200
+  transportPort: 9300
+  elasticsearchVersion: 7.16.2
+  storageSize: 20Gi
+  storageClassName: managed-premium #FIXME: populate and use
+  disk:
+    name: my-disk-name
+    uri: https://mydisk.blob.core.windows.net/mycontainer/mydisk.vhd
+  resources:
+    requests:
+      cpu: "2"
+      memory: 4Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+
+


### PR DESCRIPTION
### CronJobs

Allows the ability to define a list of cronjob in Values.yaml. Currently, each CronJob can specify a "schedule" which is a cron-style string for the schedule to run the job, and a `command` which is the management command to run.

There is then a helm template in `jobs/` that loops through these Values and generates the CronJob YAML definitions. We can easily add more configurability like specifying individual resource requirements for jobs, etc. but kept it simple for now to get going.


### ElasticSearch

Sets up Elastic Search within the cluster as a StatefulSet . This needs Persistent Storage - currently, we are provisioning the azure managed disk in terraform and supplying the disk name and URI to Helm. We may want to change how we provision persistent storage for ES later, but this should be good currently.

Currently, ElasticSearch is setup to work as a single replica - there would be a little bit of additional work to do if we wanted to run multiple replicas, but I don't think we need to worry about that for now.

cc @geohacker 